### PR TITLE
Preserve quantity when using [add_to_cart] shortcode

### DIFF
--- a/woocommerce-thumbnail-input-quantity.php
+++ b/woocommerce-thumbnail-input-quantity.php
@@ -109,11 +109,19 @@ class WooCommerce_Thumbnail_Input_Quantity {
 				} else {
 					$min = 1;
 				}
-		
-				// Add the data-quantity attribute to the button
-				$pos = strrpos( $text, "href" ); 
-				$text = substr($text, 0, $pos) . 'data-quantity="' . $min . '" ' . substr($text, $pos);
-				
+
+				// data-quantity attribute
+				if ( false === strpos( $text, 'data-quantity=' ) ) {
+					// The data-quantity attribute isn't already part of the button, so add it
+					$pos = strrpos( $text, "href" );
+					$text = substr($text, 0, $pos) . 'data-quantity="' . $min . '" ' . substr($text, $pos);
+				} else {
+					// The data-quantity attribute is already part of the button, so ensure the input box uses the same quantity
+					$values = wp_kses_hair( $text, array() );
+					$qty = isset( $values['data-quantity']['value'] ) ? $values['data-quantity']['value'] : 1;
+					$inputbox = str_replace( 'value="1"', 'value="' . $qty . '"', $inputbox );
+				}
+
 				// Concat inputbox and text
 				$text = $inputbox . $text;
 			}


### PR DESCRIPTION
This plugin works great for shop/archive pages, but it doesn't work as expected when using it with manual `[add_to_cart]` shortcodes with a quantity other than 1.

When using this plugin with WooCommerce's built in `[add_to_cart]` shortcode, if the shortcode specifies a quantity, this plugin ignores that quantity and uses 1 instead.

For example:
`[add_to_cart id="123" quantity="12"]`
Currently produces an add to cart button with a quantity input, but the quantity input defaults to 1.

This pull request fixes that, so that if a custom quantity is specified via the shortcode, the quantity input has the correct default value.

What do you think @jtwiest?
