### PR TITLE
Issue #8 - Use get_type() instead of directly accessing product_type

### DIFF
--- a/woocommerce-thumbnail-input-quantity.php
+++ b/woocommerce-thumbnail-input-quantity.php
@@ -85,7 +85,7 @@ class WooCommerce_Thumbnail_Input_Quantity {
 		if ( $text != null and $product != null  ) {
 			
 			// Get Product Type
-			$type = $product->product_type;
+			$type = $product->get_type();
 			
 			// If Simple Add Input Box and Set data-quantity = min quantity
 			if ( $type == 'simple' ){


### PR DESCRIPTION
Fix for `Notice: product_type was called incorrectly.`